### PR TITLE
Add popup controls to save page and refresh cache highlights

### DIFF
--- a/content.js
+++ b/content.js
@@ -96,7 +96,7 @@
   }
 
   // ======== SCAN & QUERY BACKGROUND ========
-  function scanAndMark() {
+  function scanAndMark({ force = false } = {}) {
     const anchors = getArticleAnchors();
     if (!anchors.length) return;
 
@@ -115,6 +115,7 @@
         type: "CHECK_CACHED",
         pageUrl: location.href,
         urls: [...map.keys()],
+        force,
       },
       (resp) => {
         if (!resp || !resp.ok) return;
@@ -192,6 +193,8 @@
   const messageListener = (msg) => {
     if (msg?.type === "TOAST" && msg.text) {
       showToast(msg.text);
+    } else if (msg?.type === "FORCE_RESCAN") {
+      scanAndMark({ force: true });
     }
   };
   chrome.runtime.onMessage.addListener(messageListener);

--- a/manifest.json
+++ b/manifest.json
@@ -7,7 +7,8 @@
   "host_permissions": ["http://bevo.ly:8002/*"],
   "background": { "service_worker": "sw.js" },
   "action": {
-    "default_title": "Save current page to cache"
+    "default_title": "Cached Article Highlighter",
+    "default_popup": "popup.html"
   },
   "content_scripts": [
     {

--- a/popup.html
+++ b/popup.html
@@ -1,0 +1,51 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Cached Article Highlighter</title>
+    <style>
+      body {
+        font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+        margin: 0;
+        padding: 12px;
+        width: 220px;
+        background: #f6f8f9;
+        color: #1d1f20;
+      }
+      h1 {
+        font-size: 14px;
+        margin: 0 0 10px;
+        text-align: center;
+      }
+      button {
+        display: block;
+        width: 100%;
+        margin-bottom: 8px;
+        padding: 8px 10px;
+        font-size: 13px;
+        border-radius: 6px;
+        border: 1px solid rgba(60, 64, 67, 0.3);
+        background: #fff;
+        cursor: pointer;
+        transition: background 0.15s ease, border-color 0.15s ease;
+      }
+      button:last-of-type {
+        margin-bottom: 0;
+      }
+      button:hover:not(:disabled) {
+        background: #eff7f2;
+        border-color: rgba(46, 204, 113, 0.6);
+      }
+      button:disabled {
+        opacity: 0.6;
+        cursor: progress;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Cached Highlighter</h1>
+    <button id="save-btn">Save current page to cache</button>
+    <button id="refresh-btn">Refresh cached link highlights</button>
+    <script src="popup.js"></script>
+  </body>
+</html>

--- a/popup.js
+++ b/popup.js
@@ -1,0 +1,58 @@
+async function getActiveTab() {
+  const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+  return tab;
+}
+
+function showTemporaryStatus(button, originalText, tempText, duration = 1200) {
+  button.textContent = tempText;
+  setTimeout(() => {
+    button.textContent = originalText;
+    button.disabled = false;
+  }, duration);
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+  const saveBtn = document.getElementById("save-btn");
+  const refreshBtn = document.getElementById("refresh-btn");
+
+  saveBtn.addEventListener("click", async () => {
+    if (saveBtn.disabled) return;
+    const originalText = saveBtn.textContent;
+    saveBtn.disabled = true;
+    saveBtn.textContent = "Saving…";
+    try {
+      const tab = await getActiveTab();
+      if (!tab) throw new Error("No active tab");
+      const response = await chrome.runtime.sendMessage({
+        type: "SAVE_URL",
+        url: tab.url,
+        tabId: tab.id,
+      });
+      if (!response?.ok) {
+        throw new Error(response?.error || "Save failed");
+      }
+      showTemporaryStatus(saveBtn, originalText, "Saved!");
+      window.close();
+    } catch (error) {
+      console.error("Save failed", error);
+      showTemporaryStatus(saveBtn, originalText, "Save failed");
+    }
+  });
+
+  refreshBtn.addEventListener("click", async () => {
+    if (refreshBtn.disabled) return;
+    const originalText = refreshBtn.textContent;
+    refreshBtn.disabled = true;
+    refreshBtn.textContent = "Refreshing…";
+    try {
+      const tab = await getActiveTab();
+      if (!tab) throw new Error("No active tab");
+      await chrome.tabs.sendMessage(tab.id, { type: "FORCE_RESCAN" });
+      showTemporaryStatus(refreshBtn, originalText, "Requested!");
+      window.close();
+    } catch (error) {
+      console.error("Refresh failed", error);
+      showTemporaryStatus(refreshBtn, originalText, "Refresh failed");
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add a browser action popup with dedicated buttons to save the current page or refresh cached link highlights
- allow the content script to force bypass the cached response when rechecking links
- route save requests through the service worker so the popup can trigger the existing save logic

## Testing
- not run (extension change only)


------
https://chatgpt.com/codex/tasks/task_e_68e1831d6b948331989adc54bfd940f7