### PR TITLE
Capture pages as PDF and alert on failures

### DIFF
--- a/content.js
+++ b/content.js
@@ -193,6 +193,8 @@
   const messageListener = (msg) => {
     if (msg?.type === "TOAST" && msg.text) {
       showToast(msg.text);
+    } else if (msg?.type === "ERROR_DIALOG" && msg.text) {
+      window.alert(msg.text);
     } else if (msg?.type === "FORCE_RESCAN") {
       scanAndMark({ force: true });
     }

--- a/popup.js
+++ b/popup.js
@@ -36,6 +36,7 @@ document.addEventListener("DOMContentLoaded", () => {
     } catch (error) {
       console.error("Save failed", error);
       showTemporaryStatus(saveBtn, originalText, "Save failed");
+      alert(error?.message || "Failed to save page as PDF");
     }
   });
 


### PR DESCRIPTION
## Summary
- capture the active tab as a PDF before saving pages to the cache backend
- send the PDF payload, including a generated filename, to the backend endpoint
- surface save failures via alerts in the popup/content script so users see an explicit error dialog

## Testing
- not run (extension code)


------
https://chatgpt.com/codex/tasks/task_e_68e2ea4dde0483319605e43f2bfd3817