### PR TITLE
Add local PDF download when caching pages

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
   "name": "Cached Article Highlighter",
   "version": "0.2.0",
   "description": "Highlights cached links and lets you save the current page to the backend.",
-  "permissions": ["storage", "activeTab", "contextMenus"],
+  "permissions": ["storage", "activeTab", "contextMenus", "downloads"],
   "host_permissions": ["http://bevo.ly:8002/*"],
   "background": { "service_worker": "sw.js" },
   "action": {


### PR DESCRIPTION
## Summary
- add the downloads permission to enable saving PDFs to disk
- create a helper that downloads captured PDFs locally and call it after uploading to the backend
- update the save confirmation toast to reflect both backend and local saves

## Testing
- Not run (extension change)


------
https://chatgpt.com/codex/tasks/task_e_68e2eccd8b2883319220e1a9a65a69dc